### PR TITLE
feat: Support apple cert root file path in param

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library to read and validate [App Store Server Notifications V2](https://develop
 pip install app-store-notifications-v2-validator
 ```
 
-Download "Apple Root CA - G3 Root" from https://www.apple.com/certificateauthority/. Store the file path in an environment variable named `APPLE_ROOT_CA` or put it in the directory where the code is run.
+Download "Apple Root CA - G3 Root" from https://www.apple.com/certificateauthority/. Store the file path in an environment variable named `APPLE_ROOT_CA` or pass file path as apple_root_cert_path param in asn2.parse or put it in the directory where the code is run.
 
 ## Usage
 

--- a/app_store_notifications_v2_validator/__init__.py
+++ b/app_store_notifications_v2_validator/__init__.py
@@ -19,7 +19,7 @@ def add_labels(key: str) -> bytes:
 def _get_root_cert(root_cert_path):
 
   fn = os.environ.get("APPLE_ROOT_CA")
-  if not fn:
+  if fn is not None:
     fn = root_cert_path or "AppleRootCA-G3.cer"
 
   fn = os.path.expanduser(fn)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="app-store-notifications-v2-validator",
-    version="0.0.5",
+    version="0.0.6",
     author="Rick Wierenga",
     author_email="rick_wierenga@icloud.com",
     description="AppStore notifications v2 Validator",
@@ -25,9 +25,9 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "cffi==1.15.1",
-        "cryptography==39.0.1",
+        "cryptography==40.0.2",
         "pycparser==2.21",
-        "PyJWT==2.3.0",
+        "PyJWT==2.7.0",
         "pyOpenSSL==23.0.0"
     ]
 )


### PR DESCRIPTION
Adding apple cert root file path in param gives more flexibity in program. 
Bumped versions of cryptography to 40.0.2 and PyJWT to 2.7.0