### PR TITLE
Early return based on presence of "data" instead of "TEST" notification

### DIFF
--- a/app_store_notifications_v2_validator/__init__.py
+++ b/app_store_notifications_v2_validator/__init__.py
@@ -65,7 +65,7 @@ def parse(req_body, apple_root_cert_path=None, algorithms=["ES256"]):
   # decode main token
   payload = _decode_jws(token, root_cert_path=apple_root_cert_path, algorithms=algorithms)
 
-  if payload['notificationType'] == 'TEST':
+  if "data" not in payload:
     return payload
 
   # decode signedTransactionInfo & substitute decoded into payload


### PR DESCRIPTION
As the [documentation](https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload#properties) states, the decoded payload fields "data", "summary" and "externalPurchaseToken" are mutually exclusive. By checking for the presence of the "data" field instead of the "TEST" notification type, we add support for notifications with "summary" and "externalPurchaseToken" fields instead of "data".